### PR TITLE
Throw ForbiddenException when client is not in server's listen.allowed_clients.

### DIFF
--- a/src/Adoy/FastCGI/Client.php
+++ b/src/Adoy/FastCGI/Client.php
@@ -10,6 +10,7 @@
 namespace Adoy\FastCGI;
 
 class TimedOutException extends \Exception {}
+class ForbiddenException extends \Exception {}
 
 /**
  * Handles communication with a FastCGI application
@@ -545,6 +546,12 @@ class Client
 
             if ($info['timed_out']) {
                 throw new TimedOutException('Read timed out');
+            }
+
+            if ($info['unread_bytes'] == 0
+                    && $info['blocked']
+                    && $info['eof']) {
+                throw new ForbiddenException('Not in white list. Check listen.allowed_clients.');
             }
 
             throw new \Exception('Read failed');


### PR DESCRIPTION
Now, it throws normal Exception with comment 'Read failed'.
