### PR TITLE
Improvements of command line tool

### DIFF
--- a/fcgiget.php
+++ b/fcgiget.php
@@ -23,15 +23,23 @@ use Adoy\FastCGI\Client;
 if (!isset($_SERVER['argc'])) {
     die("Command line only\n");
 }
-if ($_SERVER['argc']<2) {
+
+function print_usage_and_exit() {
     echo "Usage: ".$_SERVER['argv'][0]."  URI\n\n";
     echo "Ex: ".$_SERVER['argv'][0]." localhost:9000/status\n";
-    echo "Ex: ".$_SERVER['argv'][0]." unix:/var/run/php-fpm/web.sock/status\n";
+    echo "Ex: ".$_SERVER['argv'][0]." unix:/var/run/php-fpm/web.sock /status\n";
     exit(1);
 }
 
-if (preg_match('|^unix:(.*.sock)(/.*)$|', $_SERVER['argv'][1], $reg)) {
-    $url  = parse_url($reg[2]);
+if ($_SERVER['argc']<2) {
+    print_usage_and_exit();
+}
+
+if (preg_match('|^unix:(.*)$|', $_SERVER['argv'][1], $reg)) {
+    if ($_SERVER['argc'] < 3) {
+        print_usage_and_exit();
+    }
+    $url  = parse_url($_SERVER['argv'][2]);
     $sock = $reg[1];
     if (!file_exists($sock)) {
         die("UDS $sock not found\n");

--- a/fcgiget.php
+++ b/fcgiget.php
@@ -54,7 +54,7 @@ if (!$url || !isset($url['path'])) {
     die("Malformed URI");
 }
 
-$req = '/'.basename($url['path']);
+$req = $url['path'];
 if (isset($url['query'])) {
     $uri = $req .'?'.$url['query'];
 } else {

--- a/fcgiget.php
+++ b/fcgiget.php
@@ -27,7 +27,7 @@ if (!isset($_SERVER['argc'])) {
 function print_usage_and_exit() {
     echo "Usage: ".$_SERVER['argv'][0]."  URI\n\n";
     echo "Ex: ".$_SERVER['argv'][0]." localhost:9000/status\n";
-    echo "Ex: ".$_SERVER['argv'][0]." unix:/var/run/php-fpm/web.sock /status\n";
+    echo "Ex: ".$_SERVER['argv'][0]." unix:///var/run/php-fpm/web.sock /status\n";
     exit(1);
 }
 
@@ -35,7 +35,7 @@ if ($_SERVER['argc']<2) {
     print_usage_and_exit();
 }
 
-if (preg_match('|^unix:(.*)$|', $_SERVER['argv'][1], $reg)) {
+if (preg_match('|^unix://(.*)$|', $_SERVER['argv'][1], $reg)) {
     if ($_SERVER['argc'] < 3) {
         print_usage_and_exit();
     }


### PR DESCRIPTION
1. Separate Unix domain socket filepath and script filepath into two command line arguments.
2. Use common scheme for unix domain socket filepath, i.e. replace `unix:` with `unix://`.
3. Show full script path in log and send full script path in SCRIPT_NAME, REQUEST_URI and DOCUMENT_URI.
